### PR TITLE
Expand user directory when searching the path

### DIFF
--- a/moz-phab
+++ b/moz-phab
@@ -141,6 +141,7 @@ def which(filename):
     # backport of shutil.which from py3
     seen = set()
     for path in os.environ.get("PATH", os.defpath).split(os.pathsep):
+        path = os.path.expanduser(path)
         norm_path = os.path.normcase(path)
         if norm_path not in seen:
             seen.add(norm_path)


### PR DESCRIPTION
This will allow `arc` to reliably be found when the entry in $PATH looks like "~/phabricator/arcanist/bin" (as currently suggested by the documentation).