### PR TITLE
Add support for the XDG Base Directory Specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,15 @@ as with any other Python script:
 
 ### Configuration
 
-`moz-phab` has an INI style configuration file to control defaults: `~/.moz-phab-config`
+`moz-phab` has an INI style configuration file to control defaults: `moz-phab-config.ini`
+The location of this file is platform dependent, following the table:
+
+| OS | Location |
+| --- | --- |
+| Linux | ${XDG_CONFIG_HOME:-~/.config}/moz-phab-config.ini |
+| Windows | %APPDATA%\moz-phab-config.ini |
+| MacOS | ${XDG_CONFIG_HOME:-~/Library/Preferences}/moz-phab-config.ini |
+
 
 This file will be created if it doesn't exist.
 

--- a/moz-phab
+++ b/moz-phab
@@ -136,6 +136,21 @@ MINIMUM_MERCURIAL_VERSION = LooseVersion("4.3.3")
 #
 
 
+def getXDGdir():
+    platform = sys.platform
+    default = os.path.expanduser("~")
+    if platform == "linux" or platform == "linux2":
+        default = os.path.join(default, ".config")
+        path = os.getenv("XDG_CONFIG_HOME", default)
+    elif platform == "darwin":  # MACOS
+        default = os.path.join(default, "Library", "Preferences")
+        path = os.getenv("XDG_CONFIG_HOME", default)
+    elif platform == "win32" or platform == "win64":
+        default = os.path.join(default, "AppData")
+        path = os.getenv("APPDATA", default)
+    return path
+
+
 def which(filename):
     # backport of shutil.which from py3
     seen = set()
@@ -315,8 +330,8 @@ class Error(Exception):
 
 class Config(object):
     def __init__(self, should_access_file=True):
-        self._filename = os.path.join(os.path.expanduser("~"), ".moz-phab-config")
-        self.name = "~/.moz-phab-config"  # human-readable name
+        self._filename = os.path.join(getXDGdir(), "moz-phab-config.ini")
+        self.name = "moz-phab-config.ini"  # human-readable name
 
         # Default values.
         defaults = u"""


### PR DESCRIPTION
The main purpose of  XDG Base Dir Spec is to declutter mainly hidden dirs and hidden files from the user's home directory (some apps normally have a root dir/file that appears as $HOME/.myapp). It defines where files should be stored following some conventions. [More info here.](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)

With this, the configuration file **moz-phab-config.ini** is saved as described in README.md for each platform.