### PR TITLE
Bug 1681604 - Add python 3.9 to the testing matrix in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ workflows:
       - test_3_6
       - test_3_7
       - test_3_8
+      - test_3_9
       - test_win
       - test_package
 
@@ -67,6 +68,10 @@ jobs:
     <<: *test_template
     docker:
       - image: circleci/python:3.8
+  test_3_9:
+    <<: *test_template
+    docker:
+      - image: circleci/python:3.9
 
   test_win:
     executor:


### PR DESCRIPTION
Please use [Phabricator](https://phabricator.services.mozilla.com/) to submit changes.
You can do that by calling `moz-phab`.
