### PR TITLE
Bug 1741686: bump python-hglib to 2.6.2 and make requirement the minimum r?zeid

### DIFF
--- a/dev/requirements/base.in
+++ b/dev/requirements/base.in
@@ -8,7 +8,7 @@ immutabledict==1.0.0
 mock==3.0.5
 pbr==5.4.3
 pytest==5.2.1
-python-hglib==2.6.2
+python-hglib>=2.6.2
 scandir==1.10.0
 hg-evolve==10.2.0.post1
 mercurial==5.7

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         "distro",
         "glean-sdk>=36.0.0",
-        "python-hglib==2.6.1",
+        "python-hglib>=2.6.2",
         "sentry-sdk>=0.14.3",
         "setuptools",
     ],


### PR DESCRIPTION
Differential Revision: https://phabricator.services.mozilla.com/D131618

Please use [Phabricator](https://phabricator.services.mozilla.com/) to submit changes.
You can do that by calling `moz-phab`.
