### PR TITLE
Bug 1966288 - workflows: import pr-close from mozilla-firefox/firefox

### DIFF
--- a/.github/workflows/README
+++ b/.github/workflows/README
@@ -1,0 +1,7 @@
+IMPORTANT
+
+All changes and/or additions to GitHub Workflows MUST be approved by the
+Mozilla GitHub Enterprise Administrators Team.
+
+See https://mozilla-hub.atlassian.net/l/cp/f5ypVsa7 for contact information, or
+reach out on Matrix: https://chat.mozilla.org/#/room/#github-admin:mozilla.org

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -1,0 +1,20 @@
+name: close pull request
+on:
+  pull_request_target:
+    types: [opened, reopened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: "README.md"
+          sparse-checkout-cone-mode: false
+      - name: close
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.number }}
+        run: |
+          gh pr close ${{ env.PR }} --comment "(Automated Close) Please do not file pull requests here, see https://github.com/mozilla-conduit/review?tab=readme-ov-file#submitting-patches"
+          gh pr lock ${{ env.PR }}


### PR DESCRIPTION
This is a rather ironic PR, as it disables PR support.

It needs to be landed as a PR because the Lando App is not authorised to change GitHub workflows, and we'd rather keep it like that for now.

Differential Revision: https://phabricator.services.mozilla.com/D249221
